### PR TITLE
[Feat] 식당 인기 메뉴 목록 조회 API 구현

### DIFF
--- a/src/main/java/hyundai_6th_team/hyundai_6th_team/controller/RestAreaController.java
+++ b/src/main/java/hyundai_6th_team/hyundai_6th_team/controller/RestAreaController.java
@@ -1,0 +1,36 @@
+package hyundai_6th_team.hyundai_6th_team.controller;
+
+import hyundai_6th_team.hyundai_6th_team.apiPayload.ApiResponse;
+import hyundai_6th_team.hyundai_6th_team.converter.MenuConverter;
+import hyundai_6th_team.hyundai_6th_team.dto.response.RestaurantResponse;
+import hyundai_6th_team.hyundai_6th_team.entity.Menu;
+import hyundai_6th_team.hyundai_6th_team.entity.Restaurant;
+import hyundai_6th_team.hyundai_6th_team.service.RestaurantService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "휴게소", description = "휴게소 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/rest-areas")
+public class RestAreaController {
+
+    private final RestaurantService restaurantsService;
+
+    @GetMapping("/restaurants/{restaurantId}/menus")
+    @Operation(summary = "식당의 인기 메뉴 목록 조회 API",description = "특정 식당의 별점순 상위 3개의 메뉴를 조회하는 API입니다.")
+    @Parameters({
+            @Parameter(name = "restaurantId", description = "식당Id, path variable 입니다.")
+    })
+    public ApiResponse<RestaurantResponse.MenuListDTO> getMenuList(@Valid @PathVariable(name = "restaurantId") Long restaurantId){
+        List<Menu> menuList = restaurantsService.findMenu(restaurantId);
+        return ApiResponse.onSuccess(MenuConverter.toMenuListDTO(menuList));
+    }
+}

--- a/src/main/java/hyundai_6th_team/hyundai_6th_team/converter/MenuConverter.java
+++ b/src/main/java/hyundai_6th_team/hyundai_6th_team/converter/MenuConverter.java
@@ -1,0 +1,29 @@
+package hyundai_6th_team.hyundai_6th_team.converter;
+
+import hyundai_6th_team.hyundai_6th_team.dto.response.RestaurantResponse;
+import hyundai_6th_team.hyundai_6th_team.entity.Menu;
+import hyundai_6th_team.hyundai_6th_team.entity.Rating;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class MenuConverter {
+    public static RestaurantResponse.MenuDTO toMenuDTO(Menu menu) {
+        return RestaurantResponse.MenuDTO.builder()
+                .name(menu.getName())
+                .rating(String.format("%.1f", menu.calculateAverageRating()))
+                .price(String.valueOf(menu.getPrice()))
+                .build();
+    }
+
+    public static RestaurantResponse.MenuListDTO toMenuListDTO(List<Menu> menuList) {
+        List<RestaurantResponse.MenuDTO> menuDTOList = menuList.stream()
+                .map(MenuConverter::toMenuDTO)
+                .sorted(Comparator.comparing(RestaurantResponse.MenuDTO::getRating).reversed()) // rating에 따라 내림차순 정렬
+                .limit(3) // 상위 3개만 선택
+                .collect(Collectors.toList());
+
+        return new RestaurantResponse.MenuListDTO(menuDTOList);
+    }
+}

--- a/src/main/java/hyundai_6th_team/hyundai_6th_team/dto/response/RestaurantResponse.java
+++ b/src/main/java/hyundai_6th_team/hyundai_6th_team/dto/response/RestaurantResponse.java
@@ -1,0 +1,30 @@
+package hyundai_6th_team.hyundai_6th_team.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class RestaurantResponse {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MenuDTO{
+        String name;
+        String rating;
+        String price;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MenuListDTO{
+        List<MenuDTO> menuDTOList;
+    }
+
+}

--- a/src/main/java/hyundai_6th_team/hyundai_6th_team/entity/Menu.java
+++ b/src/main/java/hyundai_6th_team/hyundai_6th_team/entity/Menu.java
@@ -7,6 +7,8 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -30,4 +32,19 @@ public class Menu extends BaseEntity {
     private Integer price;
 
     private String imageUrl;
+
+    @OneToMany(mappedBy = "menu", cascade = CascadeType.ALL)
+    private List<Rating> ratingList = new ArrayList<>();
+
+    public float calculateAverageRating() {
+        if (ratingList.isEmpty()) {
+            return 0.0f; // 평점이 없는 경우 0을 반환
+        }
+
+        return (float) ratingList.stream()
+                .mapToDouble(Rating::getRating)
+                .average()
+                .orElse(0.0); // 평균 계산, 값이 없는 경우 0을 반환
+    }
+
 }

--- a/src/main/java/hyundai_6th_team/hyundai_6th_team/repository/MenuRepository.java
+++ b/src/main/java/hyundai_6th_team/hyundai_6th_team/repository/MenuRepository.java
@@ -1,0 +1,11 @@
+package hyundai_6th_team.hyundai_6th_team.repository;
+
+import hyundai_6th_team.hyundai_6th_team.entity.Menu;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MenuRepository extends JpaRepository<Menu, Long> {
+    List<Menu> findByRestaurantId(Long restaurantId);
+}

--- a/src/main/java/hyundai_6th_team/hyundai_6th_team/service/RestaurantService.java
+++ b/src/main/java/hyundai_6th_team/hyundai_6th_team/service/RestaurantService.java
@@ -1,0 +1,23 @@
+package hyundai_6th_team.hyundai_6th_team.service;
+
+import hyundai_6th_team.hyundai_6th_team.entity.Menu;
+import hyundai_6th_team.hyundai_6th_team.entity.Rating;
+import hyundai_6th_team.hyundai_6th_team.repository.MenuRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RestaurantService {
+
+    private final MenuRepository menuRepository;
+
+    public List<Menu> findMenu(Long restaurantId){
+        return menuRepository.findByRestaurantId(restaurantId);
+    }
+
+}


### PR DESCRIPTION
## 📌 작업 요약
- 요청값으로 "식당id"를 받음
- 식당의 최상위 별점 3개 메뉴를 응답(최대 3개)

## ✨ 작업 내용 및 리뷰 포인트
https://github.com/softeerbootcamp-3nd/softee5-hyundaittakdae-BE/blob/04515186a514160dde5aca4bfb9fbe6faff9302c/src/main/java/hyundai_6th_team/hyundai_6th_team/converter/MenuConverter.java#L20-L27
주요 로직을 정리하자면 다음과 같습니다.
1. Menu 엔티티 리스트 스트림으로 변환
2. 스트림의 각 Menu 엔터티를 RestaurantResponse.MenuDTO 객체로 매핑
   + 이 과정에서 각 메뉴의 평점도 계산됩니다.
3. 변환된 MenuDTO 객체들을 평점에 따라 내림차순으로 정렬
4. 정렬된 MenuDTO 리스트에서 상위 3개의 객체만 선택

조금 복잡하다는 생각도 드는데 아직까지는 더 나은 로직이 생각나지 않네요... 
더 좋은 방법이 있어보인다면 언제든 공유해주세요!

## 💡 이슈 번호
Resolve: #18 
